### PR TITLE
chore: Only set version to v0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datetime-rs"
-version = "1.0.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Luke Sneeringer <luke@sneeringer.com>"]
 description = "Date and time"


### PR DESCRIPTION
Until #5 is fixed, this shouldn't go 1.0.